### PR TITLE
docs: add crates.io mirror guide for China users

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,20 @@ open src-tauri/target/release/bundle/dmg/Ink_0.2.0_aarch64.dmg
 > [!TIP]
 > 想用但不想自己装？把这个 GitHub 链接发给 Claude Code / Cursor / 任何能读 README + 跑 shell 的 agent——它会照上面的步骤装起来。
 
+> **国内用户提示**：编译时 crates.io 下载超时，可以配置国内镜像：
+>
+> ```bash
+> # ~/.cargo/config.toml
+> [source.crates-io]
+> replace-with = "rsproxy"
+>
+> [source.rsproxy]
+> registry = "https://rsproxy.cn/crates.io-index"
+>
+> [registries.rsproxy]
+> index = "https://rsproxy.cn/crates.io-index"
+> ```
+
 ## 打开 md 的姿势
 
 - Finder 双击 `.md` / `.markdown` / `.mdx`


### PR DESCRIPTION
## Summary

- 在快速开始章节的构建步骤后，新增国内用户配置 crates.io 镜像的提示
- 使用 rsproxy.cn 作为镜像源，解决编译时 crates.io 下载超时问题

## Test plan

- [x] 确认 README 渲染正常
- [x] 国内环境按文档配置后可正常执行 `pnpm tauri build`